### PR TITLE
Support hierarchical engine attachments

### DIFF
--- a/assets/engine/assembly.json
+++ b/assets/engine/assembly.json
@@ -12,6 +12,22 @@
     {
       "name": "connecting_rod",
       "mesh": "3d/connecting_rod.glb",
+      "parent": {
+        "name": "crankshaft",
+        "attachment": "crank_pin"
+      },
+      "attachments": {
+        "crank_pin": {
+          "self": {
+            "position": [0.0, 0.0, 0.0],
+            "rotationEuler": [0.0, 0.0, 0.0]
+          },
+          "parent": {
+            "position": [0.00043, 0.02121, -0.00012],
+            "rotationEuler": [0.0, 0.0, 0.0]
+          }
+        }
+      },
       "anchor": {
         "position": [0.00005, 0.10785, -0.00018],
         "rotationEuler": [0.0, 0.0, 0.0],
@@ -21,6 +37,22 @@
     {
       "name": "piston",
       "mesh": "3d/piston.glb",
+      "parent": {
+        "name": "connecting_rod",
+        "attachment": "wrist_pin"
+      },
+      "attachments": {
+        "wrist_pin": {
+          "self": {
+            "position": [0.0, 0.0, 0.0],
+            "rotationEuler": [0.0, 0.0, 0.0]
+          },
+          "parent": {
+            "position": [0.00003, 0.02595, -0.00014],
+            "rotationEuler": [0.0, 0.0, 0.0]
+          }
+        }
+      },
       "anchor": {
         "position": [0.00008, 0.1338, -0.00032],
         "rotationEuler": [0.0, 0.0, 0.0],
@@ -39,6 +71,22 @@
     {
       "name": "valve_subassemble",
       "mesh": "3d/valve_subassemble.glb",
+      "parent": {
+        "name": "camshaft",
+        "attachment": "tappet_mount"
+      },
+      "attachments": {
+        "tappet_mount": {
+          "self": {
+            "position": [0.0, 0.0, 0.0],
+            "rotationEuler": [0.0, 0.0, 0.0]
+          },
+          "parent": {
+            "position": [0.00447, 0.07717, 0.00006],
+            "rotationEuler": [0.0, 0.0, 0.0]
+          }
+        }
+      },
       "anchor": {
         "position": [-0.00003, 0.25717, 0.00006],
         "rotationEuler": [0.0, 0.0, 0.0],

--- a/native/engine/core/engine_assembly.cpp
+++ b/native/engine/core/engine_assembly.cpp
@@ -4,6 +4,8 @@
 #include <android/log.h>
 
 #include <algorithm>
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <limits>
 #include <string>
@@ -79,6 +81,21 @@ Vec3 ParseVec3(const JsonValue& array, const Vec3& fallback) {
     };
 }
 
+Mat4 ParseTransform(const JsonValue& json, const Mat4& fallback) {
+    if (!json.IsObject()) {
+        return fallback;
+    }
+    Vec3 position{0.0f, 0.0f, 0.0f};
+    Vec3 rotation{0.0f, 0.0f, 0.0f};
+    if (json.Contains("position")) {
+        position = ParseVec3(json["position"], position);
+    }
+    if (json.Contains("rotationEuler")) {
+        rotation = ParseVec3(json["rotationEuler"], rotation);
+    }
+    return ComposeTransform(position, rotation);
+}
+
 }  // namespace
 
 EngineAssembly::~EngineAssembly() {
@@ -121,6 +138,36 @@ bool EngineAssembly::Load(AAssetManager* assetManager, const std::string& mappin
         partLookup_[parts_[i].name] = i;
     }
 
+    for (size_t i = 0; i < parts_.size(); ++i) {
+        auto& part = parts_[i];
+        part.parentIndex = static_cast<size_t>(-1);
+        if (part.parentName.empty()) {
+            continue;
+        }
+        auto parentIt = partLookup_.find(part.parentName);
+        if (parentIt == partLookup_.end()) {
+            __android_log_print(ANDROID_LOG_ERROR, kTag,
+                                "Part '%s' references missing parent '%s'",
+                                part.name.c_str(), part.parentName.c_str());
+            continue;
+        }
+        if (parentIt->second == i) {
+            __android_log_print(ANDROID_LOG_ERROR, kTag,
+                                "Part '%s' cannot parent itself", part.name.c_str());
+            continue;
+        }
+        part.parentIndex = parentIt->second;
+        if (part.parentAttachmentName.empty()) {
+            __android_log_print(ANDROID_LOG_WARN, kTag,
+                                "Part '%s' specifies parent '%s' without attachment name",
+                                part.name.c_str(), part.parentName.c_str());
+        } else if (!part.hasRelativeAttachment) {
+            __android_log_print(ANDROID_LOG_WARN, kTag,
+                                "Part '%s' attachment '%s' missing transform data",
+                                part.name.c_str(), part.parentAttachmentName.c_str());
+        }
+    }
+
     return !parts_.empty();
 }
 
@@ -135,30 +182,38 @@ void EngineAssembly::Destroy() {
 std::vector<PartAnchor> EngineAssembly::Anchors() const {
     std::vector<PartAnchor> anchors;
     anchors.reserve(parts_.size());
-    for (const auto& part : parts_) {
+    const std::vector<Mat4> defaults = BuildDefaultTransforms();
+    for (size_t i = 0; i < parts_.size(); ++i) {
+        const auto& part = parts_[i];
         PartAnchor anchor;
         anchor.name = part.name;
-        anchor.transform = part.anchorTransform;
+        anchor.parentName = part.parentName;
+        anchor.attachmentName = part.parentAttachmentName;
+        anchor.defaultTransform = defaults.empty() ? part.anchorTransform : defaults[i];
+        if (!part.parentAttachmentName.empty()) {
+            auto attachmentIt = part.attachments.find(part.parentAttachmentName);
+            if (attachmentIt != part.attachments.end()) {
+                anchor.selfAttachment = attachmentIt->second.self;
+                anchor.parentAttachment = attachmentIt->second.parent;
+            }
+        }
         anchors.push_back(anchor);
     }
     return anchors;
 }
 
 void EngineAssembly::ApplyTransforms(const std::vector<PartTransform>& transforms) {
-    if (transforms.empty()) {
-        for (auto& part : parts_) {
-            part.currentTransform = part.anchorTransform;
-        }
-        return;
-    }
-
-    for (auto& part : parts_) {
-        part.currentTransform = part.anchorTransform;
+    const std::vector<Mat4> defaults = BuildDefaultTransforms();
+    for (size_t i = 0; i < parts_.size(); ++i) {
+        parts_[i].currentTransform = defaults.empty() ? parts_[i].anchorTransform : defaults[i];
     }
 
     for (const auto& transform : transforms) {
         auto it = partLookup_.find(transform.name);
         if (it == partLookup_.end()) {
+            __android_log_print(ANDROID_LOG_WARN, kTag,
+                                "Ignoring transform for unknown part '%s'",
+                                transform.name.c_str());
             continue;
         }
         parts_[it->second].currentTransform = transform.transform;
@@ -195,6 +250,58 @@ bool EngineAssembly::LoadPart(AAssetManager* assetManager,
         }
         if (anchor.Contains("color")) {
             color = ParseVec3(anchor["color"], color);
+        }
+    }
+
+    if (partJson.Contains("attachments")) {
+        const JsonValue& attachments = partJson["attachments"];
+        if (attachments.IsObject()) {
+            for (const auto& entry : attachments.AsObject()) {
+                EnginePart::AttachmentPair pair;
+                const std::string& name = entry.first;
+                const JsonValue& attachmentValue = entry.second;
+                if (attachmentValue.Contains("self")) {
+                    pair.self = ParseTransform(attachmentValue["self"], pair.self);
+                } else {
+                    __android_log_print(ANDROID_LOG_WARN, kTag,
+                                        "Attachment '%s' for part '%s' missing 'self' transform",
+                                        name.c_str(), part.name.c_str());
+                }
+                if (attachmentValue.Contains("parent")) {
+                    pair.parent = ParseTransform(attachmentValue["parent"], pair.parent);
+                } else {
+                    __android_log_print(ANDROID_LOG_WARN, kTag,
+                                        "Attachment '%s' for part '%s' missing 'parent' transform",
+                                        name.c_str(), part.name.c_str());
+                }
+                part.attachments.emplace(name, pair);
+            }
+        }
+    }
+
+    if (partJson.Contains("parent")) {
+        const JsonValue& parentValue = partJson["parent"];
+        if (parentValue.Contains("name")) {
+            part.parentName = parentValue["name"].AsString("");
+        }
+        if (parentValue.Contains("attachment")) {
+            part.parentAttachmentName = parentValue["attachment"].AsString("");
+        }
+        if (!part.parentAttachmentName.empty()) {
+            auto attachmentIt = part.attachments.find(part.parentAttachmentName);
+            if (attachmentIt != part.attachments.end()) {
+                part.relativeAttachment = CombineAttachmentTransforms(attachmentIt->second.parent,
+                                                                      attachmentIt->second.self);
+                part.hasRelativeAttachment = true;
+            } else {
+                __android_log_print(ANDROID_LOG_WARN, kTag,
+                                    "Part '%s' references missing attachment '%s'",
+                                    part.name.c_str(), part.parentAttachmentName.c_str());
+            }
+        } else if (!part.parentName.empty()) {
+            __android_log_print(ANDROID_LOG_WARN, kTag,
+                                "Part '%s' specifies parent '%s' without attachment",
+                                part.name.c_str(), part.parentName.c_str());
         }
     }
 
@@ -254,6 +361,48 @@ bool EngineAssembly::LoadPart(AAssetManager* assetManager,
 
     parts_.push_back(std::move(part));
     return true;
+}
+
+Mat4 EngineAssembly::ResolveDefaultTransform(size_t index,
+                                             std::vector<Mat4>* cache,
+                                             std::vector<uint8_t>* state) const {
+    if (index >= parts_.size()) {
+        return Mat4::Identity();
+    }
+    if ((*state)[index] == 2) {
+        return (*cache)[index];
+    }
+    if ((*state)[index] == 1) {
+        __android_log_print(ANDROID_LOG_ERROR, kTag,
+                            "Cycle detected while resolving transforms for part '%s'",
+                            parts_[index].name.c_str());
+        return (*cache)[index];
+    }
+
+    (*state)[index] = 1;
+    const EnginePart& part = parts_[index];
+    Mat4 transform = part.anchorTransform;
+    if (part.parentIndex != static_cast<size_t>(-1) && part.parentIndex < parts_.size()) {
+        const Mat4 parentTransform = ResolveDefaultTransform(part.parentIndex, cache, state);
+        if (part.hasRelativeAttachment) {
+            transform = Multiply(parentTransform, part.relativeAttachment);
+        }
+    }
+    (*cache)[index] = transform;
+    (*state)[index] = 2;
+    return transform;
+}
+
+std::vector<Mat4> EngineAssembly::BuildDefaultTransforms() const {
+    if (parts_.empty()) {
+        return {};
+    }
+    std::vector<Mat4> cache(parts_.size(), Mat4::Identity());
+    std::vector<uint8_t> state(parts_.size(), 0);
+    for (size_t i = 0; i < parts_.size(); ++i) {
+        ResolveDefaultTransform(i, &cache, &state);
+    }
+    return cache;
 }
 
 }  // namespace engine

--- a/native/engine/core/engine_assembly.h
+++ b/native/engine/core/engine_assembly.h
@@ -20,6 +20,16 @@ struct EnginePart {
     Vec3 color{0.7f, 0.7f, 0.7f};
     Mat4 anchorTransform{Mat4::Identity()};
     Mat4 currentTransform{Mat4::Identity()};
+    std::string parentName;
+    std::string parentAttachmentName;
+    size_t parentIndex{static_cast<size_t>(-1)};
+    Mat4 relativeAttachment{Mat4::Identity()};
+    bool hasRelativeAttachment{false};
+    struct AttachmentPair {
+        Mat4 self{Mat4::Identity()};
+        Mat4 parent{Mat4::Identity()};
+    };
+    std::unordered_map<std::string, AttachmentPair> attachments;
 
     EnginePart() = default;
     EnginePart(const EnginePart&) = delete;
@@ -47,6 +57,11 @@ private:
     bool LoadPart(AAssetManager* assetManager,
                   const std::string& basePath,
                   const JsonValue& partJson);
+
+    Mat4 ResolveDefaultTransform(size_t index,
+                                 std::vector<Mat4>* cache,
+                                 std::vector<uint8_t>* state) const;
+    std::vector<Mat4> BuildDefaultTransforms() const;
 
     std::vector<EnginePart> parts_;
     std::unordered_map<std::string, size_t> partLookup_;

--- a/native/engine/core/math_types.h
+++ b/native/engine/core/math_types.h
@@ -215,5 +215,39 @@ inline Mat4 ComposeTransform(const Vec3& translation, const Vec3& rotationDegree
     return Multiply(trans, rot);
 }
 
+inline Mat4 InvertRigidTransform(const Mat4& transform) {
+    Mat4 result = Mat4::Identity();
+
+    // Extract rotation matrix (upper-left 3x3) and transpose it.
+    result.data[0] = transform.data[0];
+    result.data[1] = transform.data[4];
+    result.data[2] = transform.data[8];
+
+    result.data[4] = transform.data[1];
+    result.data[5] = transform.data[5];
+    result.data[6] = transform.data[9];
+
+    result.data[8] = transform.data[2];
+    result.data[9] = transform.data[6];
+    result.data[10] = transform.data[10];
+
+    const Vec3 translation{transform.data[12], transform.data[13], transform.data[14]};
+    const Vec3 rotated{
+        result.data[0] * translation.x + result.data[4] * translation.y + result.data[8] * translation.z,
+        result.data[1] * translation.x + result.data[5] * translation.y + result.data[9] * translation.z,
+        result.data[2] * translation.x + result.data[6] * translation.y + result.data[10] * translation.z
+    };
+
+    result.data[12] = -rotated.x;
+    result.data[13] = -rotated.y;
+    result.data[14] = -rotated.z;
+
+    return result;
+}
+
+inline Mat4 CombineAttachmentTransforms(const Mat4& parentAttachment, const Mat4& selfAttachment) {
+    return Multiply(parentAttachment, InvertRigidTransform(selfAttachment));
+}
+
 }  // namespace engine
 

--- a/native/engine/core/physics_stub.cpp
+++ b/native/engine/core/physics_stub.cpp
@@ -1,14 +1,117 @@
 #include "engine/core/physics_stub.h"
 
+#include <android/log.h>
+
+#include <cstdint>
+#include <functional>
+#include <unordered_map>
+#include <utility>
+
+#include "engine/core/math_types.h"
+
 namespace engine {
+namespace {
+constexpr const char* kTag = "PhysicsStub";
+constexpr size_t kInvalidIndex = static_cast<size_t>(-1);
+}
 
 void PhysicsSystemStub::SetAnchors(const std::vector<PartAnchor>& anchors) {
+    struct Node {
+        std::string name;
+        std::string parentName;
+        size_t parentIndex{kInvalidIndex};
+        bool hasRelative{false};
+        Mat4 relative{Mat4::Identity()};
+        Mat4 fallback{Mat4::Identity()};
+    };
+
     transforms_.clear();
-    transforms_.reserve(anchors.size());
+    if (anchors.empty()) {
+        return;
+    }
+
+    std::vector<Node> nodes;
+    nodes.reserve(anchors.size());
+    std::unordered_map<std::string, size_t> lookup;
+    lookup.reserve(anchors.size());
+
     for (const auto& anchor : anchors) {
+        Node node;
+        node.name = anchor.name;
+        node.parentName = anchor.parentName;
+        node.fallback = anchor.defaultTransform;
+        if (!anchor.attachmentName.empty()) {
+            node.relative = CombineAttachmentTransforms(anchor.parentAttachment, anchor.selfAttachment);
+            node.hasRelative = true;
+        } else if (!anchor.parentName.empty()) {
+            __android_log_print(ANDROID_LOG_WARN, kTag,
+                                "Anchor '%s' specifies parent '%s' without attachment name",
+                                anchor.name.c_str(), anchor.parentName.c_str());
+        }
+        lookup[node.name] = nodes.size();
+        nodes.push_back(std::move(node));
+    }
+
+    for (size_t i = 0; i < nodes.size(); ++i) {
+        Node& node = nodes[i];
+        if (node.parentName.empty()) {
+            continue;
+        }
+        auto it = lookup.find(node.parentName);
+        if (it == lookup.end()) {
+            __android_log_print(ANDROID_LOG_ERROR, kTag,
+                                "Anchor '%s' references missing parent '%s'",
+                                node.name.c_str(), node.parentName.c_str());
+            continue;
+        }
+        if (it->second == i) {
+            __android_log_print(ANDROID_LOG_ERROR, kTag,
+                                "Anchor '%s' cannot be its own parent", node.name.c_str());
+            continue;
+        }
+        node.parentIndex = it->second;
+        if (!node.hasRelative) {
+            __android_log_print(ANDROID_LOG_WARN, kTag,
+                                "Anchor '%s' missing attachment transforms for parent '%s'",
+                                node.name.c_str(), node.parentName.c_str());
+        }
+    }
+
+    std::vector<Mat4> resolved(nodes.size(), Mat4::Identity());
+    std::vector<uint8_t> state(nodes.size(), 0);
+
+    std::function<Mat4(size_t)> resolve = [&](size_t index) -> Mat4 {
+        if (index >= nodes.size()) {
+            return Mat4::Identity();
+        }
+        if (state[index] == 2) {
+            return resolved[index];
+        }
+        if (state[index] == 1) {
+            __android_log_print(ANDROID_LOG_ERROR, kTag,
+                                "Cycle detected when resolving anchor '%s'",
+                                nodes[index].name.c_str());
+            return resolved[index];
+        }
+
+        state[index] = 1;
+        Mat4 transform = nodes[index].fallback;
+        if (nodes[index].parentIndex != kInvalidIndex) {
+            const Mat4 parentTransform = resolve(nodes[index].parentIndex);
+            if (nodes[index].hasRelative) {
+                transform = Multiply(parentTransform, nodes[index].relative);
+            }
+        }
+        resolved[index] = transform;
+        state[index] = 2;
+        return transform;
+    };
+
+    transforms_.reserve(nodes.size());
+    for (size_t i = 0; i < nodes.size(); ++i) {
         PartTransform transform;
-        transform.name = anchor.name;
-        transform.transform = anchor.transform;
+        transform.name = nodes[i].name;
+        transform.transform = resolve(i);
         transforms_.push_back(transform);
     }
 }

--- a/native/engine/core/physics_stub.h
+++ b/native/engine/core/physics_stub.h
@@ -15,7 +15,11 @@ struct EngineControlInputs {
 
 struct PartAnchor {
     std::string name;
-    Mat4 transform{Mat4::Identity()};
+    std::string parentName;
+    std::string attachmentName;
+    Mat4 defaultTransform{Mat4::Identity()};
+    Mat4 selfAttachment{Mat4::Identity()};
+    Mat4 parentAttachment{Mat4::Identity()};
 };
 
 struct PartTransform {


### PR DESCRIPTION
## Summary
- extend the engine assembly asset to describe parent relationships and attachment transforms
- propagate attachment metadata through EngineAssembly so default poses are built from the hierarchy and diagnostics surface configuration issues
- update the physics stub to traverse the attachment graph when computing transforms

## Testing
- not run (native build system not available)

------
https://chatgpt.com/codex/tasks/task_e_68e139c4d168832a83d6bb46d12e295f