### PR TITLE
Combine GLTF primitives into unified mesh buffers

### DIFF
--- a/native/engine/core/mesh.cpp
+++ b/native/engine/core/mesh.cpp
@@ -39,6 +39,7 @@ bool Mesh::Initialize(const std::vector<float>& positions,
     }
 
     const size_t vertexCount = positions.size() / 3;
+    const bool hasNormals = normals.size() == positions.size();
     std::vector<float> interleaved;
     interleaved.reserve(vertexCount * 6);
 
@@ -47,7 +48,7 @@ bool Mesh::Initialize(const std::vector<float>& positions,
         interleaved.push_back(positions[i * 3 + 1]);
         interleaved.push_back(positions[i * 3 + 2]);
 
-        if (!normals.empty()) {
+        if (hasNormals) {
             interleaved.push_back(normals[i * 3 + 0]);
             interleaved.push_back(normals[i * 3 + 1]);
             interleaved.push_back(normals[i * 3 + 2]);


### PR DESCRIPTION
## Summary
- gather vertex, normal, and index data from every primitive in each GLTF mesh
- ensure mesh initialization copes with combined buffers and mismatched normal data

## Testing
- `./gradlew :app:assembleDebug` *(fails: gradlew script not present in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e67fa62024832a8014c4f7d893c4af