### PR TITLE
Fix theme data types for Flutter 3.22

### DIFF
--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -49,7 +49,7 @@ class AppTheme {
       textTheme: _buildTextTheme(),
       
       // Card theme
-      cardTheme: CardTheme(
+      cardTheme: CardThemeData(
         color: AppColors.surface,
         elevation: DesignTokens.elevationMedium,
         shape: RoundedRectangleBorder(
@@ -148,7 +148,7 @@ class AppTheme {
       ),
       
       // Dialog theme
-      dialogTheme: DialogTheme(
+      dialogTheme: DialogThemeData(
         backgroundColor: AppColors.surface,
         elevation: DesignTokens.elevationHigh,
         shape: RoundedRectangleBorder(


### PR DESCRIPTION
## Summary
- replace deprecated CardTheme usage with the new CardThemeData class
- update dialog configuration to use DialogThemeData for compatibility with Flutter 3.22

## Testing
- flutter analyze *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ea405fed08832a85aac9f7e5db0a3c