### PR TITLE
Fix piston slider axis source

### DIFF
--- a/native/engine/core/kinematics_system.cpp
+++ b/native/engine/core/kinematics_system.cpp
@@ -239,8 +239,16 @@ void KinematicsSystem::BuildSliderCrankData() {
     sliderCrank_.rodSmallLocal = rodToPistonRodGeom.position;
     sliderCrank_.rodBigLocal = rodBigGeom.position;
     sliderCrank_.pistonLocal = rodToPistonPistonGeom.position;
-    sliderCrank_.pistonAxis = Normalize(TransformDirection(sliderCrank_.pistonDefault,
-                                                           rodToPistonPistonGeom.axis));
+
+    sliderCrank_.pistonAxis = Vec3{0.0f, 1.0f, 0.0f};
+    ConstraintGeometry pistonGroundGeom;
+    if (findConcentric("piston", std::string{}, &pistonGroundGeom, nullptr)) {
+        sliderCrank_.pistonAxis = Normalize(
+            TransformDirection(sliderCrank_.pistonDefault, pistonGroundGeom.axis));
+    } else {
+        sliderCrank_.pistonAxis = Normalize(
+            TransformDirection(sliderCrank_.pistonDefault, rodToPistonPistonGeom.axis));
+    }
     if (Length(sliderCrank_.pistonAxis) <= std::numeric_limits<float>::epsilon()) {
         sliderCrank_.pistonAxis = Vec3{0.0f, 1.0f, 0.0f};
     }


### PR DESCRIPTION
## Summary
- use the piston-to-ground concentric constraint to derive the slider axis for the piston
- fall back to the wrist-pin constraint axis when the ground reference is unavailable while keeping normalization guards

## Testing
- Not run (native code change only)


------
https://chatgpt.com/codex/tasks/task_e_68f11997aec0832a8f61baac548f1c07